### PR TITLE
chore: add automatic docker build and push on new version release

### DIFF
--- a/.github/workflows/docker_build_and_push.yaml
+++ b/.github/workflows/docker_build_and_push.yaml
@@ -1,0 +1,49 @@
+name: Build and Push Docker Image to Google Artifact Registry
+
+on:
+  # This allows manual activation of this action for testing.
+  workflow_dispatch:
+  push:
+    tags:
+      # Automatically build and push Docker image when a release (version) tag is pushed.
+      - v*
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF: ${{ github.ref }}
+  IMAGE: cassandra-adapter
+  GCR_HOSTNAME: gcr.io/cloud-spanner-adapter
+
+jobs:
+  setup-build-publish-deploy:
+    name: Setup, Build, and Publish
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - id: 'auth'
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: '${{ secrets.SPANNER_CASSANDRA_ADAPTER_DOCKER_SERVICE_ACCOUNT }}'
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+
+      # Configure docker to use the gcloud command-line tool as a credential helper
+      - run: gcloud auth configure-docker gcr.io
+
+      # Build and Publish the Docker images
+      - name: Build and Publish
+        run: |
+          export TAG=`echo $GITHUB_REF | awk -F/ '{print $NF}'`
+          echo $TAG
+          docker buildx create --name multi_platform --use
+          docker buildx build --platform linux/amd64,linux/arm64 \
+            . \
+            -t "$GCR_HOSTNAME"/"$IMAGE":"$TAG" \
+            -t "$GCR_HOSTNAME"/"$IMAGE":latest \
+            --push \
+            --build-arg GITHUB_SHA="$GITHUB_SHA" \
+            --build-arg GITHUB_REF="$GITHUB_REF"


### PR DESCRIPTION
This workflow can not be tested locally, will need to push to main first to test.