### PR TITLE
chore: change release type to go-yoshi

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,6 +1,6 @@
 handleGHRelease: true
 manifest: true
-releaseType: go
+releaseType: go-yoshi
 bumpMinorPreMajor: true
 
 branches:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-  "release-type": "go",
+  "release-type": "go-yoshi",
   "separate-pull-requests": true,
   "include-component-in-tag": false,
   "packages": {


### PR DESCRIPTION
This is to keep consistent with our client libraries.