### PR TITLE
feat: support suppress api client options on start

### DIFF
--- a/.github/workflows/build_and_tests.yaml
+++ b/.github/workflows/build_and_tests.yaml
@@ -21,11 +21,6 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: '1.23'
-    
-    - id: 'auth'
-      uses: 'google-github-actions/auth@v2'
-      with:
-          credentials_json: '${{ secrets.SPANNER_CASSANDRA_ADAPTER_CICD_SERVICE_ACCOUNT }}'
 
     - name: build
       run: go build -v ./...
@@ -34,6 +29,11 @@ jobs:
       run: |
           go mod tidy
           go test -v -tags=unit ./... 
+    
+    - id: 'auth'
+      uses: 'google-github-actions/auth@v2'
+      with:
+          credentials_json: '${{ secrets.SPANNER_CASSANDRA_ADAPTER_CICD_SERVICE_ACCOUNT }}'
 
     - name: it tests against Spanner 
       run: |

--- a/adapter/client_test.go
+++ b/adapter/client_test.go
@@ -62,7 +62,8 @@ func TestGetOrRefreshSession(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			SessionRefreshTimeInterval = tt.refreshInterval
 			cl, err := newAdapterClient(context.Background(), Options{
-				DatabaseUri: "test",
+				DatabaseUri:   "test",
+				GoogleApiOpts: SkipAuthOpts,
 			})
 			assert.NoError(t, err)
 			cl.session = tt.initialSession

--- a/adapter/options.go
+++ b/adapter/options.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package adapter
 
+import "google.golang.org/api/option"
+
 // Options for configuring the adapter.
 type Options struct {
 	// Spanner database uri to connect to.
@@ -31,4 +33,6 @@ type Options struct {
 	// Optional boolean indicate whether to disable automatic grpc retry for
 	// AdaptMessage API. Defauls to false.
 	DisableAdaptMessageRetry bool
+	// Optional google api opts. Default to empty.
+	GoogleApiOpts []option.ClientOption
 }

--- a/adapter/test_util.go
+++ b/adapter/test_util.go
@@ -28,12 +28,25 @@ import (
 	"github.com/datastax/go-cassandra-native-protocol/datatype"
 	"github.com/datastax/go-cassandra-native-protocol/frame"
 	"github.com/datastax/go-cassandra-native-protocol/message"
+	"google.golang.org/api/option"
+	"google.golang.org/api/option/internaloption"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 )
 
 var (
 	selectPreparedId = "select_id"
 	dmlPreparedId    = "dml_id"
+	// api options to disable application default credential in unit test
+	SkipAuthOpts = []option.ClientOption{
+		option.WithEndpoint("localhost:443"),
+		option.WithGRPCDialOption(
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		),
+		option.WithoutAuthentication(),
+		internaloption.SkipDialSettingsValidation(),
+	}
 )
 
 type GrpcFuncs struct {

--- a/cassandra/gocql/spanner.go
+++ b/cassandra/gocql/spanner.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/googleapis/go-spanner-cassandra/adapter"
 	"github.com/googleapis/go-spanner-cassandra/logger"
+	"google.golang.org/api/option"
 )
 
 // Map from cluster config to local proxies.
@@ -47,6 +48,8 @@ type Options struct {
 	DisableAdaptMessageRetry bool
 	// Optional log level. Defaults to info.
 	LogLevel string
+	// Optional google api opts. Default to empty.
+	GoogleApiOpts []option.ClientOption
 }
 
 type ProxyAddressTranslator struct {
@@ -79,6 +82,7 @@ func NewCluster(
 			Protocol:                 &cassandraProtocol{},
 			NumGrpcChannels:          opts.NumGrpcChannels,
 			DisableAdaptMessageRetry: opts.DisableAdaptMessageRetry,
+			GoogleApiOpts:            opts.GoogleApiOpts,
 		},
 	)
 	if err != nil {

--- a/cassandra/gocql/spanner_test.go
+++ b/cassandra/gocql/spanner_test.go
@@ -42,7 +42,8 @@ func setupCluster(
 	adapter.MockCreateSessionGrpc()
 	adapter.MockAdaptMessageGrpc(returnResponsesInChunks)
 	opts := &Options{
-		DatabaseUri: "projects/test/instances/test/databases/test",
+		DatabaseUri:   "projects/test/instances/test/databases/test",
+		GoogleApiOpts: adapter.SkipAuthOpts,
 	}
 
 	cluster := NewCluster(opts)
@@ -245,8 +246,9 @@ func TestNewClusterPanicsOnInvalidLogLevel(t *testing.T) {
 			adapter.MockCreateSessionGrpc()
 
 			opts := &Options{
-				DatabaseUri: "projects/test/instances/test/databases/test",
-				LogLevel:    tc.logLevel,
+				DatabaseUri:   "projects/test/instances/test/databases/test",
+				LogLevel:      tc.logLevel,
+				GoogleApiOpts: adapter.SkipAuthOpts,
 			}
 
 			callNewCluster := func() {


### PR DESCRIPTION
- Needed for internal continuous test purpose.
- Needed for supporting E2E tracing and metric exporter in the future.
- Needed for disabling application default credential verification in unit test. Now all unit tests will not rely on having application default credentials set up in CI/CD first.