### PR TITLE
chore: Use non-token aware routing by default

### DIFF
--- a/cassandra/gocql/spanner.go
+++ b/cassandra/gocql/spanner.go
@@ -103,9 +103,9 @@ func NewCluster(
 	)
 	cfg.Port = addr.Port
 	cfg.ProtoVersion = 4
-
 	cfg.WriteCoalesceWaitTime = 0
-
+	// Use a non token aware routing policy by default
+	cfg.PoolConfig.HostSelectionPolicy = gocql.RoundRobinHostPolicy()
 	// Override default timeout settings.
 	cfg.Timeout = 60 * time.Second
 	cfg.ConnectTimeout = 60 * time.Second


### PR DESCRIPTION
This is to avoid repeated token fetching and system queries since they are technically not needed for a single node "spanner-cassandra".