### PR TITLE
ci: split unit and it tests

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build:
-    name: Build and Test
+    name: Integration Tests
     runs-on: ubuntu-latest
     steps:
     - name: checkout
@@ -25,11 +25,6 @@ jobs:
     - name: build
       run: go build -v ./...
     
-    - name: unit tests
-      run: |
-          go mod tidy
-          go test -v -tags=unit ./... 
-    
     - id: 'auth'
       uses: 'google-github-actions/auth@v2'
       with:
@@ -38,9 +33,9 @@ jobs:
     - name: it tests against Spanner 
       run: |
           go mod tidy
-          go test -v  github.com/googleapis/go-spanner-cassandra/cassandra/gocql -tags=integration
+          go test -v  ./... -tags=integration
 
     - name: it tests against Cassandra 
       run: |
           go mod tidy
-          go test -v  ./... -tags=integration
+          go test -v  ./... -tags=integration -target=cassandra

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,0 +1,26 @@
+on:
+  # This allows manual activation of this action for testing.
+  workflow_dispatch:
+  # Run unit tests on all push since they don't consume any resources
+  push:
+
+jobs:
+  build:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+
+    - name: set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.23'
+
+    - name: build
+      run: go build -v ./...
+    
+    - name: unit tests
+      run: |
+          go mod tidy
+          go test -v -tags=unit ./... 


### PR DESCRIPTION
Also run unit tests on every push on all branches since they don't consume any resources.