### PR TITLE
feat: enable leader aware routing by default for all write operations

### DIFF
--- a/adapter/connection.go
+++ b/adapter/connection.go
@@ -226,7 +226,7 @@ func (dc *driverConnection) handleConnection(ctx context.Context) {
 
 		// Send the grpc request.
 		var pbCli adapterpb.Adapter_AdaptMessageClient
-		pbCli, err = dc.executor.submit(ctx, req)
+		pbCli, err = dc.executor.submit(ctx, req, isDML(&req.frame))
 		if err != nil {
 			logger.Error("Error sending AdaptMessageRequest to server",
 				zap.Int("connectionID", int(dc.connectionID)),
@@ -253,5 +253,4 @@ func (dc *driverConnection) handleConnection(ctx context.Context) {
 			)
 		}
 	}
-
 }

--- a/adapter/constants.go
+++ b/adapter/constants.go
@@ -20,6 +20,8 @@ const (
 	// Maximum size of local singleton state maintained across all requests.
 	// ~100mb
 	maxGlobalStateSize = 1e8 / 256
-	// prefix for prepared query id state updates
+	// Prefix for prepared query id state updates.
 	preparedQueryIdAttachmentPrefix = "pqid/"
+	// Prefix for Message.QueryId if this query id belongs to a DML statement.
+	writeActionQueryIdPrefix = "W"
 )

--- a/adapter/executor_test.go
+++ b/adapter/executor_test.go
@@ -1,0 +1,140 @@
+//go:build unit
+// +build unit
+
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapter
+
+import (
+	"testing"
+
+	"github.com/datastax/go-cassandra-native-protocol/frame"
+	"github.com/datastax/go-cassandra-native-protocol/message"
+	"github.com/datastax/go-cassandra-native-protocol/primitive"
+)
+
+func TestIsDML(t *testing.T) {
+	// Helper function to create a frame with a given message body
+	newFrameWithMessage := func(msg message.Message) *frame.Frame {
+		opCode := msg.GetOpCode()
+		return &frame.Frame{
+			Header: &frame.Header{
+				Version:  primitive.ProtocolVersion4, // Or any relevant version
+				Flags:    0,
+				StreamId: 1,
+				OpCode:   opCode,
+			},
+			Body: &frame.Body{
+				Message: msg,
+			},
+		}
+	}
+
+	testCases := []struct {
+		name     string
+		frame    *frame.Frame
+		expected bool
+	}{
+		// Execute message
+		{
+			name: "Execute message with DML QueryId prefix",
+			frame: newFrameWithMessage(&message.Execute{
+				QueryId: []byte(writeActionQueryIdPrefix + "test-id-123"),
+			}),
+			expected: true,
+		},
+		{
+			name: "Execute message with select QueryId prefix",
+			frame: newFrameWithMessage(&message.Execute{
+				QueryId: []byte(
+					"R" + "test-id-456",
+				),
+			}),
+			expected: false,
+		},
+
+		// Batch message
+		{
+			name: "Batch message",
+			frame: newFrameWithMessage(&message.Batch{
+				Type: primitive.BatchTypeLogged,
+			}),
+			expected: true,
+		},
+
+		// Query message
+		{
+			name: "Query message with 'select' (lowercase)",
+			frame: newFrameWithMessage(&message.Query{
+				Query: "select * from users where id = 1",
+			}),
+			expected: false,
+		},
+		{
+			name: "Query message with 'SELECT' (uppercase)",
+			frame: newFrameWithMessage(&message.Query{
+				Query: "SELECT * from users where id = 1",
+			}),
+			expected: false,
+		},
+		{
+			name: "Query message with 'SeLeCt' (mixed case)",
+			frame: newFrameWithMessage(&message.Query{
+				Query: "SeLeCt * from users where id = 1",
+			}),
+			expected: false,
+		},
+		{
+			name: "Query message with non-select prefix",
+			frame: newFrameWithMessage(&message.Query{
+				Query: "insert into users (id, name) values (1, 'John')",
+			}),
+			expected: true,
+		},
+
+		// Other messages
+		{
+			name:     "Default message type - Options",
+			frame:    newFrameWithMessage(&message.Options{}),
+			expected: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := isDML(tc.frame)
+			if actual != tc.expected {
+				var queryDetail string
+
+				switch msg := tc.frame.Body.Message.(type) {
+				case *message.Query:
+					queryDetail = "Query: " + msg.Query
+				case *message.Execute:
+					queryDetail = "Execute QueryId: " + string(msg.QueryId)
+				default:
+					queryDetail = "Message Type: " + tc.frame.Body.Message.GetOpCode().String()
+				}
+				t.Errorf(
+					"isDML() for test case '%s' (%s) = %v, want %v",
+					tc.name,
+					queryDetail,
+					actual,
+					tc.expected,
+				)
+			}
+		})
+	}
+}

--- a/adapter/tcp.go
+++ b/adapter/tcp.go
@@ -111,10 +111,9 @@ func NewTCPProxy(opts Options) (*TCPProxy, error) {
 				protocol:      opts.Protocol,
 				adapterClient: proxy.client,
 				executor: &requestExecutor{
-					protocol:     opts.Protocol,
-					client:       proxy.client,
-					globalState:  proxy.globalState,
-					xGoogHeaders: cl.xGoogHeaders,
+					protocol:    opts.Protocol,
+					client:      proxy.client,
+					globalState: proxy.globalState,
 				},
 				driverConn:  conn,
 				globalState: proxy.globalState,


### PR DESCRIPTION
This pr enables route to leader header for below cases:

- Batch message
- Execute message with query id starts with `W`(prefix for write operation)
- Query message with query string does not starts with `select`(can be mixed case)