### PR TITLE
ci: fix flaky it test on session timeout

### DIFF
--- a/cassandra/gocql/integration_test.go
+++ b/cassandra/gocql/integration_test.go
@@ -951,7 +951,7 @@ func TestCreateSessionTimeout(t *testing.T) {
 	}()
 
 	localCluster := *cluster
-	localCluster.ConnectTimeout = 1 * time.Millisecond
+	localCluster.Hosts = []string{"127.0.0.1:1"}
 	session, err := localCluster.CreateSession()
 	if err == nil {
 		session.Close()


### PR DESCRIPTION
We should connect cluster to invalid port rather than relying on extremely short time out