### PR TITLE
chore: add an internal generic testutil package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/datastax/go-cassandra-native-protocol v0.0.0-20240903140133-605a850e203b
 	github.com/gocql/gocql v1.7.0
 	github.com/google/go-cmp v0.7.0
-	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.14.1
 	github.com/hashicorp/golang-lru v1.0.2
 	github.com/stretchr/testify v1.10.0
@@ -16,6 +15,7 @@ require (
 	google.golang.org/api v0.228.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250407143221-ac9807e6c755
 	google.golang.org/grpc v1.71.1
+	google.golang.org/protobuf v1.36.6
 )
 
 require (
@@ -50,6 +50,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
@@ -91,7 +92,6 @@ require (
 	golang.org/x/time v0.11.0 // indirect
 	google.golang.org/genproto v0.0.0-20250303144028-a0af3efb3deb // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250407143221-ac9807e6c755 // indirect
-	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/testutil/cmp.go
+++ b/internal/testutil/cmp.go
@@ -1,0 +1,61 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"math"
+	"math/big"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/proto"
+)
+
+var (
+	alwaysEqual = cmp.Comparer(func(_, _ interface{}) bool { return true })
+
+	defaultCmpOptions = []cmp.Option{
+		// Use proto.Equal for protobufs
+		cmp.Comparer(proto.Equal),
+		// Use big.Rat.Cmp for big.Rats
+		cmp.Comparer(func(x, y *big.Rat) bool {
+			if x == nil || y == nil {
+				return x == y
+			}
+			return x.Cmp(y) == 0
+		}),
+		// NaNs compare equal
+		cmp.FilterValues(func(x, y float64) bool {
+			return math.IsNaN(x) && math.IsNaN(y)
+		}, alwaysEqual),
+		cmp.FilterValues(func(x, y float32) bool {
+			return math.IsNaN(float64(x)) && math.IsNaN(float64(y))
+		}, alwaysEqual),
+	}
+)
+
+// Equal tests two values for equality.
+func Equal(x, y interface{}, opts ...cmp.Option) bool {
+	// Put default options at the end. Order doesn't matter.
+	opts = append(opts[:len(opts):len(opts)], defaultCmpOptions...)
+	return cmp.Equal(x, y, opts...)
+}
+
+// Diff reports the differences between two values.
+// Diff(x, y) == "" iff Equal(x, y).
+func Diff(x, y interface{}, opts ...cmp.Option) string {
+	// Put default options at the end. Order doesn't matter.
+	opts = append(opts[:len(opts):len(opts)], defaultCmpOptions...)
+	return cmp.Diff(x, y, opts...)
+}


### PR DESCRIPTION
This will be needed for future metric tests, largely replicated from https://github.com/googleapis/google-cloud-go/blob/main/internal/testutil/cmp.go