### PR TITLE
chore: add base framework for built in metrics

### DIFF
--- a/adapter/metrics.go
+++ b/adapter/metrics.go
@@ -1,0 +1,567 @@
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/contrib/detectors/gcp"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	builtInMetricsMeterName = "gax-go"
+	grpcMetricMeterName     = "grpc-go"
+
+	nativeMetricsPrefix = "spanner.googleapis.com/internal/client/"
+
+	// Monitored resource labels
+	monitoredResLabelKeyProject        = "project_id"
+	monitoredResLabelKeyInstance       = "instance_id"
+	monitoredResLabelKeyInstanceConfig = "instance_config"
+	monitoredResLabelKeyLocation       = "location"
+	monitoredResLabelKeyClientHash     = "client_hash"
+
+	// Metric labels
+	metricLabelKeyClientUID             = "client_uid"
+	metricLabelKeyClientName            = "client_name"
+	metricLabelKeyDatabase              = "database"
+	metricLabelKeyMethod                = "method"
+	metricLabelKeyStatus                = "status"
+	metricLabelKeyDirectPathEnabled     = "directpath_enabled"
+	metricLabelKeyDirectPathUsed        = "directpath_used"
+	metricLabelKeyGRPCLBPickResult      = "grpc.lb.pick_result"
+	metricLabelKeyGRPCLBDataPlaneTarget = "grpc.lb.rls.data_plane_target"
+
+	// Metric names
+	metricNameOperationLatencies = "operation_latencies"
+	metricNameOperationCount     = "operation_count"
+
+	// Metric units
+	metricUnitMS    = "ms"
+	metricUnitCount = "1"
+)
+
+// These are effectively const, but for testing purposes they are mutable
+var (
+	// duration between two metric exports
+	defaultSamplePeriod = 1 * time.Minute
+
+	clientName = fmt.Sprintf("spanner-cassandra-go/%v", version)
+
+	// TODO: disable lint for this long block
+	bucketBounds = []float64{
+		0.0,
+		0.5,
+		1.0,
+		2.0,
+		3.0,
+		4.0,
+		5.0,
+		6.0,
+		7.0,
+		8.0,
+		9.0,
+		10.0,
+		11.0,
+		12.0,
+		13.0,
+		14.0,
+		15.0,
+		16.0,
+		17.0,
+		18.0,
+		19.0,
+		20.0,
+		25.0,
+		30.0,
+		40.0,
+		50.0,
+		65.0,
+		80.0,
+		100.0,
+		130.0,
+		160.0,
+		200.0,
+		250.0,
+		300.0,
+		400.0,
+		500.0,
+		650.0,
+		800.0,
+		1000.0,
+		2000.0,
+		5000.0,
+		10000.0,
+		20000.0,
+		50000.0,
+		100000.0,
+		200000.0,
+		400000.0,
+		800000.0,
+		1600000.0,
+		3200000.0,
+	}
+
+	// These attributes need to be added to only few of the metrics
+	metricsDetails = map[string]metricInfo{
+		metricNameOperationCount: {
+			additionalAttrs: []string{
+				metricLabelKeyStatus,
+			},
+			recordedPerAttempt: false,
+		},
+		metricNameOperationLatencies: {
+			additionalAttrs: []string{
+				metricLabelKeyStatus,
+			},
+			recordedPerAttempt: false,
+		},
+	}
+
+	// Generates unique client ID in the format go-<random UUID>@<hostname>
+	generateClientUID = func() (string, error) {
+		hostname := "localhost"
+		hostname, err := os.Hostname()
+		if err != nil {
+			return "", err
+		}
+		return uuid.NewString() + "@" + strconv.FormatInt(
+			int64(os.Getpid()),
+			10,
+		) + "@" + hostname, nil
+	}
+
+	// generateClientHash generates a 6-digit zero-padded lowercase hexadecimal
+	// hash
+	// using the 10 most significant bits of a 64-bit hash value.
+	//
+	// The primary purpose of this function is to generate a hash value for the
+	// `client_hash` resource label using `client_uid` metric field. The range of
+	// values is chosen to be small enough to keep the cardinality of the Resource
+	// targets under control. Note: If at later time the range needs to be
+	// increased, it can be done by increasing the value of `kPrefixLength` to
+	// up to 24 bits without changing the format of the returned value.
+	generateClientHash = func(clientUID string) string {
+		if clientUID == "" {
+			return "000000"
+		}
+
+		// Use FNV hash function to generate a 64-bit hash
+		hasher := fnv.New64()
+		hasher.Write([]byte(clientUID))
+		hashValue := hasher.Sum64()
+
+		// Extract the 10 most significant bits
+		// Shift right by 54 bits to get the 10 most significant bits
+		kPrefixLength := 10
+		tenMostSignificantBits := hashValue >> (64 - kPrefixLength)
+
+		// Format the result as a 6-digit zero-padded hexadecimal string
+		return fmt.Sprintf("%06x", tenMostSignificantBits)
+	}
+
+	detectClientLocation = func(ctx context.Context) string {
+		resource, err := gcp.NewDetector().Detect(ctx)
+		if err != nil {
+			return "global"
+		}
+		for _, attr := range resource.Attributes() {
+			if attr.Key == semconv.CloudRegionKey {
+				return attr.Value.AsString()
+			}
+		}
+		// If region is not found, return global
+		return "global"
+	}
+
+	// Overwritten in tests
+	createExporterOptions = func(spannerOpts ...option.ClientOption) []option.ClientOption {
+		defaultMonitoringEndpoint := "monitoring.googleapis.com:443"
+		// overwrite any Endpoint option
+		spannerOpts = append(
+			spannerOpts,
+			option.WithEndpoint(defaultMonitoringEndpoint),
+		)
+		return spannerOpts
+	}
+
+	grpcMetricsToEnable = []string{
+		"grpc.lb.rls.default_target_picks",
+		"grpc.lb.rls.target_picks",
+		"grpc.xds_client.server_failure",
+		"grpc.xds_client.resource_updates_invalid",
+		"grpc.xds_client.resource_updates_valid",
+	}
+)
+
+type metricInfo struct {
+	additionalAttrs    []string
+	recordedPerAttempt bool
+}
+
+// builtinMetricsTracerFactory is responsible for creating and managing metrics
+// tracers.
+type builtinMetricsTracerFactory struct {
+	enabled             bool // Indicates if metrics tracing is enabled.
+	isDirectPathEnabled bool // Indicates if DirectPath is enabled.
+
+	// shutdown is a function to be called on client close to clean up resources.
+	shutdown func(ctx context.Context)
+
+	// client options passed to gRPC channels
+	clientOpts []option.ClientOption
+	// clientAttributes are attributes specific to a client instance that do not
+	// change across different function calls on the client.
+	clientAttributes []attribute.KeyValue
+
+	// Metrics instruments
+	operationLatencies metric.Float64Histogram // Histogram for operation latencies.
+	operationCount     metric.Int64Counter     // Counter for the number of operations.
+}
+
+func newBuiltinMetricsTracerFactory(
+	ctx context.Context,
+	dbpath, compression string,
+	isEnableGRPCBuiltInMetrics bool,
+	metricsProvider metric.MeterProvider,
+	opts ...option.ClientOption,
+) (*builtinMetricsTracerFactory, error) {
+	clientUID, err := generateClientUID()
+	if err != nil {
+		log.Printf(
+			"built-in metrics: generateClientUID failed: %v. Using empty string in the %v metric atteribute",
+			err,
+			metricLabelKeyClientUID,
+		)
+	}
+	project, instance, database, err := parseDatabaseName(dbpath)
+	if err != nil {
+		return nil, err
+	}
+
+	tracerFactory := &builtinMetricsTracerFactory{
+		enabled: false,
+		clientAttributes: []attribute.KeyValue{
+			attribute.String(monitoredResLabelKeyProject, project),
+			attribute.String(monitoredResLabelKeyInstance, instance),
+			attribute.String(metricLabelKeyDatabase, database),
+			attribute.String(metricLabelKeyClientUID, clientUID),
+			attribute.String(metricLabelKeyClientName, clientName),
+			attribute.String(
+				monitoredResLabelKeyClientHash,
+				generateClientHash(clientUID),
+			),
+			// Skipping instance config until we have a way to get it
+			attribute.String(monitoredResLabelKeyInstanceConfig, "unknown"),
+			attribute.String(monitoredResLabelKeyLocation, detectClientLocation(ctx)),
+		},
+		shutdown: func(ctx context.Context) {},
+	}
+	tracerFactory.isDirectPathEnabled = false
+	tracerFactory.enabled = false
+	var meterProvider *sdkmetric.MeterProvider
+	if metricsProvider == nil {
+		// Create default meter provider
+		mpOptions, exporter, err := builtInMeterProviderOptions(
+			project,
+			compression,
+			tracerFactory.clientAttributes,
+			opts...)
+		if err != nil {
+			return tracerFactory, err
+		}
+		meterProvider = sdkmetric.NewMeterProvider(mpOptions...)
+
+		tracerFactory.enabled = true
+		tracerFactory.shutdown = func(ctx context.Context) {
+			exporter.stop()
+			meterProvider.Shutdown(ctx)
+		}
+	} else {
+		switch metricsProvider.(type) {
+		case noop.MeterProvider:
+			return tracerFactory, nil
+		default:
+			return tracerFactory, errors.New("unknown MetricsProvider type")
+		}
+	}
+
+	// Create meter and instruments
+	meter := meterProvider.Meter(
+		builtInMetricsMeterName,
+		metric.WithInstrumentationVersion(version),
+	)
+	err = tracerFactory.createInstruments(meter)
+	return tracerFactory, err
+}
+
+func builtInMeterProviderOptions(
+	project, compression string,
+	clientAttributes []attribute.KeyValue,
+	opts ...option.ClientOption,
+) ([]sdkmetric.Option, *monitoringExporter, error) {
+	allOpts := createExporterOptions(opts...)
+	defaultExporter, err := newMonitoringExporter(
+		context.Background(),
+		project,
+		compression,
+		clientAttributes,
+		allOpts...)
+	if err != nil {
+		return nil, nil, err
+	}
+	var views []sdkmetric.View
+	for _, m := range grpcMetricsToEnable {
+		views = append(views, sdkmetric.NewView(
+			sdkmetric.Instrument{
+				Name: m,
+			},
+			sdkmetric.Stream{
+				Aggregation: sdkmetric.AggregationSum{},
+				AttributeFilter: func(kv attribute.KeyValue) bool {
+					if _, ok := allowedMetricLabels[string(kv.Key)]; ok {
+						return true
+					}
+					return false
+				},
+			},
+		))
+	}
+	return []sdkmetric.Option{sdkmetric.WithReader(
+		sdkmetric.NewPeriodicReader(
+			defaultExporter,
+			sdkmetric.WithInterval(defaultSamplePeriod),
+		),
+	), sdkmetric.WithView(views...)}, defaultExporter, nil
+}
+
+func (tf *builtinMetricsTracerFactory) createInstruments(
+	meter metric.Meter,
+) error {
+	var err error
+
+	// Create operation_latencies
+	tf.operationLatencies, err = meter.Float64Histogram(
+		nativeMetricsPrefix+metricNameOperationLatencies,
+		metric.WithDescription(
+			"Total time until final operation success or failure.",
+		),
+		metric.WithUnit(metricUnitMS),
+		metric.WithExplicitBucketBoundaries(bucketBounds...),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Create operation_count
+	tf.operationCount, err = meter.Int64Counter(
+		nativeMetricsPrefix+metricNameOperationCount,
+		metric.WithDescription("The count of database operations."),
+		metric.WithUnit(metricUnitCount),
+	)
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+// builtinMetricsTracer is created one per operation.
+// It is used to store metric instruments, attribute values, and other data
+// required to obtain and record them.
+type builtinMetricsTracer struct {
+	ctx            context.Context // Context for the tracer.
+	builtInEnabled bool            // Indicates if built-in metrics are enabled.
+
+	// clientAttributes are attributes specific to a client instance that do not
+	// change across different operations on the client.
+	clientAttributes []attribute.KeyValue
+
+	// Metrics instruments
+	instrumentOperationLatencies metric.Float64Histogram // Histogram for operation latencies.
+	instrumentOperationCount     metric.Int64Counter     // Counter for the number of operations.
+
+	method string // The method being traced.
+
+	currOp *opTracer // The current operation tracer.
+}
+
+// opTracer is used to record metrics for the entire operation, including
+// retries. An operation is a logical unit that represents a single method
+// invocation on the client. The method might require multiple attempts/RPCs and
+// backoff logic to complete.
+type opTracer struct {
+	attemptCount int64     // The number of attempts made for the operation.
+	startTime    time.Time // The start time of the operation.
+
+	// status is the gRPC status code of the last completed attempt.
+	status string
+
+	directPathEnabled bool // Indicates if DirectPath is enabled for the operation.
+	directPathUsed    bool // Indicates if DirectPath is used for the operation.
+
+}
+
+// setStartTime sets the start time for the operation.
+func (o *opTracer) setStartTime(t time.Time) {
+	o.startTime = t
+}
+
+// setStatus sets the status for the operation.
+func (o *opTracer) setStatus(s string) {
+	o.status = s
+}
+
+// setDirectPathEnabled sets whether DirectPath is enabled for the operation.
+func (o *opTracer) setDirectPathEnabled(enabled bool) {
+	o.directPathEnabled = enabled
+}
+
+func (tf *builtinMetricsTracerFactory) createBuiltinMetricsTracer(
+	ctx context.Context,
+) builtinMetricsTracer {
+	// Operation has started but not the attempt.
+	// So, create only operation tracer and not attempt tracer
+	currOpTracer := opTracer{}
+	currOpTracer.setStartTime(time.Now())
+	currOpTracer.setDirectPathEnabled(tf.isDirectPathEnabled)
+
+	return builtinMetricsTracer{
+		ctx:              ctx,
+		builtInEnabled:   tf.enabled,
+		currOp:           &currOpTracer,
+		clientAttributes: tf.clientAttributes,
+
+		instrumentOperationLatencies: tf.operationLatencies,
+		instrumentOperationCount:     tf.operationCount,
+	}
+}
+
+// toOtelMetricAttrs: converts metric attributes values captured throughout the
+// operation/attempt to OpenTelemetry attributes format, combines these with
+// common client attributes and returns.
+func (mt *builtinMetricsTracer) toOtelMetricAttrs(
+	metricName string,
+) ([]attribute.KeyValue, error) {
+	if mt.currOp == nil {
+		return nil, fmt.Errorf(
+			"unable to create attributes list for unknown metric: %v",
+			metricName,
+		)
+	}
+	// Get metric details
+	_, found := metricsDetails[metricName]
+	if !found {
+		return nil, fmt.Errorf(
+			"unable to create attributes list for unknown metric: %v",
+			metricName,
+		)
+	}
+
+	return []attribute.KeyValue{
+		attribute.String(
+			metricLabelKeyMethod,
+			strings.ReplaceAll(
+				strings.TrimPrefix(mt.method, "/google.spanner.v1."),
+				"/",
+				".",
+			),
+		),
+		attribute.String(
+			metricLabelKeyDirectPathEnabled,
+			strconv.FormatBool(mt.currOp.directPathEnabled),
+		),
+		attribute.String(
+			metricLabelKeyDirectPathUsed,
+			strconv.FormatBool(mt.currOp.directPathUsed),
+		),
+		attribute.String(metricLabelKeyStatus, mt.currOp.status),
+	}, nil
+}
+
+// Convert error to grpc status error
+func convertToGrpcStatusErr(err error) (codes.Code, error) {
+	if err == nil {
+		return codes.OK, nil
+	}
+
+	if errStatus, ok := status.FromError(err); ok {
+		return errStatus.Code(), status.Error(errStatus.Code(), errStatus.Message())
+	}
+
+	ctxStatus := status.FromContextError(err)
+	if ctxStatus.Code() != codes.Unknown {
+		return ctxStatus.Code(), status.Error(ctxStatus.Code(), ctxStatus.Message())
+	}
+
+	return codes.Unknown, err
+}
+
+// recordOperationCompletion records as many operation specific metrics as it
+// can
+// Ignores error seen while creating metric attributes since metric can still
+// be recorded with rest of the attributes
+func recordOperationCompletion(mt *builtinMetricsTracer) {
+	if !mt.builtInEnabled {
+		return
+	}
+
+	// Calculate elapsed time
+	elapsedTimeMs := convertToMs(time.Since(mt.currOp.startTime))
+
+	// Record operation_count
+	opCntAttrs, err := mt.toOtelMetricAttrs(metricNameOperationCount)
+	if err != nil {
+		return
+	}
+	mt.instrumentOperationCount.Add(
+		mt.ctx,
+		1,
+		metric.WithAttributes(opCntAttrs...),
+	)
+
+	// Record operation_latencies
+	opLatAttrs, err := mt.toOtelMetricAttrs(metricNameOperationLatencies)
+	if err != nil {
+		return
+	}
+	mt.instrumentOperationLatencies.Record(
+		mt.ctx,
+		elapsedTimeMs,
+		metric.WithAttributes(opLatAttrs...),
+	)
+}
+
+func convertToMs(d time.Duration) float64 {
+	return float64(d.Nanoseconds()) / float64(time.Millisecond)
+}

--- a/adapter/metrics_monitoring_exporter.go
+++ b/adapter/metrics_monitoring_exporter.go
@@ -1,0 +1,458 @@
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This is a modified version of
+// https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/exporter/metric/v0.46.0/exporter/metric/metric.go
+
+package adapter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
+	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
+	"github.com/googleapis/gax-go/v2/callctx"
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/sdk/metric"
+	otelmetricdata "go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"google.golang.org/api/option"
+	"google.golang.org/genproto/googleapis/api/distribution"
+	googlemetricpb "google.golang.org/genproto/googleapis/api/metric"
+	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/encoding/gzip"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	spannerResourceType = "spanner_instance_client"
+
+	// The number of timeserieses to send to Google Cloud Monitoring in a single
+	// request. This
+	// is a hard limit in the GCM API, so we never want to exceed 200.
+	// https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.timeSeries/create
+	sendBatchSize = 200
+)
+
+var (
+	monitoredResLabelsSet = map[string]bool{
+		monitoredResLabelKeyProject:        true,
+		monitoredResLabelKeyInstance:       true,
+		monitoredResLabelKeyInstanceConfig: true,
+		monitoredResLabelKeyLocation:       true,
+		monitoredResLabelKeyClientHash:     true,
+	}
+
+	allowedMetricLabels = map[string]bool{
+		metricLabelKeyGRPCLBPickResult:      true,
+		metricLabelKeyGRPCLBDataPlaneTarget: true,
+		metricLabelKeyClientUID:             true,
+		metricLabelKeyClientName:            true,
+		metricLabelKeyDatabase:              true,
+		metricLabelKeyDirectPathEnabled:     true,
+		metricLabelKeyDirectPathUsed:        true,
+		metricLabelKeyMethod:                true,
+		metricLabelKeyStatus:                true,
+	}
+
+	errShutdown = fmt.Errorf("exporter is shutdown")
+)
+
+type errUnexpectedAggregationKind struct {
+	kind string
+}
+
+func (e errUnexpectedAggregationKind) Error() string {
+	return fmt.Sprintf("the metric kind is unexpected: %v", e.kind)
+}
+
+// monitoringExporter is the implementation of OpenTelemetry metric exporter for
+// Google Cloud Monitoring.
+// Default exporter for built-in metrics
+type monitoringExporter struct {
+	projectID        string
+	compression      string
+	clientAttributes []attribute.KeyValue
+	shutdown         chan struct{}
+	client           *monitoring.MetricClient
+	shutdownOnce     sync.Once
+
+	mu             sync.Mutex
+	stopExport     bool
+	lastExportedAt time.Time
+}
+
+func newMonitoringExporter(
+	ctx context.Context,
+	project, compression string,
+	clientAttributes []attribute.KeyValue,
+	opts ...option.ClientOption,
+) (*monitoringExporter, error) {
+	client, err := monitoring.NewMetricClient(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &monitoringExporter{
+		projectID:        project,
+		compression:      compression,
+		clientAttributes: clientAttributes,
+		lastExportedAt:   time.Now().Add(-time.Minute),
+		client:           client,
+		shutdown:         make(chan struct{}),
+	}, nil
+}
+
+func (me *monitoringExporter) stop() {
+	// stop the exporter if last export happens within half-time of default sample
+	// period
+	me.mu.Lock()
+	defer me.mu.Unlock()
+	if time.Since(me.lastExportedAt) <= (defaultSamplePeriod / 2) {
+		me.stopExport = true
+	}
+}
+
+// ForceFlush does nothing, the exporter holds no state.
+func (e *monitoringExporter) ForceFlush(
+	ctx context.Context,
+) error {
+	return ctx.Err()
+}
+
+// Shutdown shuts down the client connections.
+func (e *monitoringExporter) Shutdown(ctx context.Context) error {
+	err := errShutdown
+	e.shutdownOnce.Do(func() {
+		close(e.shutdown)
+		err = errors.Join(ctx.Err(), e.client.Close())
+	})
+	return err
+}
+
+// Export exports OpenTelemetry Metrics to Google Cloud Monitoring.
+func (me *monitoringExporter) Export(
+	ctx context.Context,
+	rm *otelmetricdata.ResourceMetrics,
+) error {
+	select {
+	case <-me.shutdown:
+		return errShutdown
+	default:
+	}
+
+	me.mu.Lock()
+	if me.stopExport {
+		me.mu.Unlock()
+		return nil
+	}
+	me.mu.Unlock()
+	return me.exportTimeSeries(ctx, rm)
+}
+
+// Temporality returns the Temporality to use for an instrument kind.
+func (me *monitoringExporter) Temporality(
+	ik otelmetric.InstrumentKind,
+) otelmetricdata.Temporality {
+	return otelmetricdata.CumulativeTemporality
+}
+
+// Aggregation returns the Aggregation to use for an instrument kind.
+func (me *monitoringExporter) Aggregation(
+	ik otelmetric.InstrumentKind,
+) otelmetric.Aggregation {
+	return otelmetric.DefaultAggregationSelector(ik)
+}
+
+// exportTimeSeries create TimeSeries from the records in cps.
+// res should be the common resource among all TimeSeries, such as instance id,
+// application name and so on.
+func (me *monitoringExporter) exportTimeSeries(
+	ctx context.Context,
+	rm *otelmetricdata.ResourceMetrics,
+) error {
+	tss, err := me.recordsToTimeSeriesPbs(rm)
+	if len(tss) == 0 {
+		return err
+	}
+	name := fmt.Sprintf("projects/%s", me.projectID)
+	// TODO: replace with the gax version from google-cloud-go/spanner/adapter/
+	ctx = callctx.SetHeaders(ctx, "x-goog-api-client", "gccl/"+version)
+	if me.compression == gzip.Name {
+		ctx = callctx.SetHeaders(ctx, requestsCompressionHeader, gzip.Name)
+	}
+	errs := []error{err}
+	for i := 0; i < len(tss); i += sendBatchSize {
+		j := i + sendBatchSize
+		if j >= len(tss) {
+			j = len(tss)
+		}
+		req := &monitoringpb.CreateTimeSeriesRequest{
+			Name:       name,
+			TimeSeries: tss[i:j],
+		}
+		err = me.client.CreateServiceTimeSeries(ctx, req)
+		if err != nil {
+			if status.Code(err) == codes.PermissionDenied {
+				err = fmt.Errorf(
+					"%w Need monitoring metric writer permission on project=%s. Follow https://cloud.google.com/spanner/docs/view-manage-client-side-metrics#access-client-side-metrics to set up permissions",
+					err,
+					me.projectID,
+				)
+			}
+		}
+		errs = append(errs, err)
+	}
+
+	me.mu.Lock()
+	me.lastExportedAt = time.Now()
+	me.mu.Unlock()
+	return errors.Join(errs...)
+}
+
+// recordToMetricAndMonitoredResourcePbs converts data from records to Metric
+// and Monitored resource proto type for Cloud Monitoring.
+func (me *monitoringExporter) recordToMetricAndMonitoredResourcePbs(
+	metrics otelmetricdata.Metrics,
+	attributes attribute.Set,
+) (*googlemetricpb.Metric, *monitoredrespb.MonitoredResource) {
+	mr := &monitoredrespb.MonitoredResource{
+		Type:   spannerResourceType,
+		Labels: map[string]string{},
+	}
+	labels := make(map[string]string)
+	addAttributes := func(attr *attribute.Set) {
+		iter := attr.Iter()
+		for iter.Next() {
+			kv := iter.Attribute()
+			// Replace metric label names by converting "." to "_" since Cloud
+			// Monitoring does not
+			// support labels containing "."
+			labelKey := strings.Replace(string(kv.Key), ".", "_", -1)
+			if _, isResLabel := monitoredResLabelsSet[labelKey]; isResLabel {
+				mr.Labels[labelKey] = kv.Value.Emit()
+			} else {
+				if _, ok := allowedMetricLabels[string(kv.Key)]; ok {
+					labels[labelKey] = kv.Value.Emit()
+				}
+			}
+		}
+		for _, label := range me.clientAttributes {
+			if _, isResLabel := monitoredResLabelsSet[string(label.Key)]; isResLabel {
+				mr.Labels[string(label.Key)] = label.Value.Emit()
+			} else {
+				labels[string(label.Key)] = label.Value.Emit()
+			}
+		}
+	}
+	metricName := metrics.Name
+	if !strings.HasPrefix(metricName, nativeMetricsPrefix) {
+		metricName = nativeMetricsPrefix + strings.Replace(metricName, ".", "/", -1)
+	}
+	addAttributes(&attributes)
+	return &googlemetricpb.Metric{
+		Type:   metricName,
+		Labels: labels,
+	}, mr
+}
+
+func (me *monitoringExporter) recordsToTimeSeriesPbs(
+	rm *otelmetricdata.ResourceMetrics,
+) ([]*monitoringpb.TimeSeries, error) {
+	var (
+		tss  []*monitoringpb.TimeSeries
+		errs []error
+	)
+	for _, scope := range rm.ScopeMetrics {
+		if !(scope.Scope.Name == builtInMetricsMeterName || scope.Scope.Name == grpcMetricMeterName) {
+			continue
+		}
+		for _, metrics := range scope.Metrics {
+			ts, err := me.recordToTimeSeriesPb(metrics)
+			errs = append(errs, err)
+			tss = append(tss, ts...)
+		}
+	}
+
+	return tss, errors.Join(errs...)
+}
+
+// recordToTimeSeriesPb converts record to TimeSeries proto type with common
+// resource.
+// ref. https://cloud.google.com/monitoring/api/ref_v3/rest/v3/TimeSeries
+func (me *monitoringExporter) recordToTimeSeriesPb(
+	m otelmetricdata.Metrics,
+) ([]*monitoringpb.TimeSeries, error) {
+	var tss []*monitoringpb.TimeSeries
+	var errs []error
+	if m.Data == nil {
+		return nil, nil
+	}
+	switch a := m.Data.(type) {
+	case otelmetricdata.Histogram[float64]:
+		for _, point := range a.DataPoints {
+			metric, mr := me.recordToMetricAndMonitoredResourcePbs(m, point.Attributes)
+			ts, err := histogramToTimeSeries(point, m, mr)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			ts.Metric = metric
+			tss = append(tss, ts)
+		}
+	case otelmetricdata.Sum[int64]:
+		for _, point := range a.DataPoints {
+			metric, mr := me.recordToMetricAndMonitoredResourcePbs(m, point.Attributes)
+			var ts *monitoringpb.TimeSeries
+			var err error
+			ts, err = sumToTimeSeries[int64](point, m, mr)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			ts.Metric = metric
+			tss = append(tss, ts)
+		}
+	default:
+		errs = append(errs, errUnexpectedAggregationKind{kind: reflect.TypeOf(m.Data).String()})
+	}
+	return tss, errors.Join(errs...)
+}
+
+func sumToTimeSeries[N int64 | float64](
+	point otelmetricdata.DataPoint[N],
+	metrics otelmetricdata.Metrics,
+	mr *monitoredrespb.MonitoredResource,
+) (*monitoringpb.TimeSeries, error) {
+	interval, err := toNonemptyTimeIntervalpb(point.StartTime, point.Time)
+	if err != nil {
+		return nil, err
+	}
+	value, valueType := numberDataPointToValue[N](point)
+	return &monitoringpb.TimeSeries{
+		Resource:   mr,
+		Unit:       string(metrics.Unit),
+		MetricKind: googlemetricpb.MetricDescriptor_CUMULATIVE,
+		ValueType:  valueType,
+		Points: []*monitoringpb.Point{{
+			Interval: interval,
+			Value:    value,
+		}},
+	}, nil
+}
+
+func histogramToTimeSeries[N int64 | float64](
+	point otelmetricdata.HistogramDataPoint[N],
+	metrics otelmetricdata.Metrics,
+	mr *monitoredrespb.MonitoredResource,
+) (*monitoringpb.TimeSeries, error) {
+	interval, err := toNonemptyTimeIntervalpb(point.StartTime, point.Time)
+	if err != nil {
+		return nil, err
+	}
+	distributionValue := histToDistribution(point)
+	return &monitoringpb.TimeSeries{
+		Resource:   mr,
+		Unit:       string(metrics.Unit),
+		MetricKind: googlemetricpb.MetricDescriptor_CUMULATIVE,
+		ValueType:  googlemetricpb.MetricDescriptor_DISTRIBUTION,
+		Points: []*monitoringpb.Point{{
+			Interval: interval,
+			Value: &monitoringpb.TypedValue{
+				Value: &monitoringpb.TypedValue_DistributionValue{
+					DistributionValue: distributionValue,
+				},
+			},
+		}},
+	}, nil
+}
+
+func toNonemptyTimeIntervalpb(
+	start, end time.Time,
+) (*monitoringpb.TimeInterval, error) {
+	// The end time of a new interval must be at least a millisecond after the end
+	// time of the
+	// previous interval, for all non-gauge types.
+	// https://cloud.google.com/monitoring/api/ref_v3/rpc/google.monitoring.v3#timeinterval
+	if end.Sub(start).Milliseconds() <= 1 {
+		end = start.Add(time.Millisecond)
+	}
+	startpb := timestamppb.New(start)
+	endpb := timestamppb.New(end)
+	err := errors.Join(
+		startpb.CheckValid(),
+		endpb.CheckValid(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &monitoringpb.TimeInterval{
+		StartTime: startpb,
+		EndTime:   endpb,
+	}, nil
+}
+
+func histToDistribution[N int64 | float64](
+	hist otelmetricdata.HistogramDataPoint[N],
+) *distribution.Distribution {
+	counts := make([]int64, len(hist.BucketCounts))
+	for i, v := range hist.BucketCounts {
+		counts[i] = int64(v)
+	}
+	var mean float64
+	if !math.IsNaN(float64(hist.Sum)) && hist.Count > 0 { // Avoid divide-by-zero
+		mean = float64(hist.Sum) / float64(hist.Count)
+	}
+	return &distribution.Distribution{
+		Count:        int64(hist.Count),
+		Mean:         mean,
+		BucketCounts: counts,
+		BucketOptions: &distribution.Distribution_BucketOptions{
+			Options: &distribution.Distribution_BucketOptions_ExplicitBuckets{
+				ExplicitBuckets: &distribution.Distribution_BucketOptions_Explicit{
+					Bounds: hist.Bounds,
+				},
+			},
+		},
+	}
+}
+
+func numberDataPointToValue[N int64 | float64](
+	point otelmetricdata.DataPoint[N],
+) (*monitoringpb.TypedValue, googlemetricpb.MetricDescriptor_ValueType) {
+	switch v := any(point.Value).(type) {
+	case int64:
+		return &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_Int64Value{
+				Int64Value: v,
+			}},
+			googlemetricpb.MetricDescriptor_INT64
+	case float64:
+		return &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{
+				DoubleValue: v,
+			}},
+			googlemetricpb.MetricDescriptor_DOUBLE
+	}
+	// It is impossible to reach this statement
+	return nil, googlemetricpb.MetricDescriptor_INT64
+}

--- a/adapter/metrics_monitoring_exporter_test.go
+++ b/adapter/metrics_monitoring_exporter_test.go
@@ -1,0 +1,138 @@
+//go:build unit
+// +build unit
+
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapter
+
+import (
+	"context"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
+	metricpb "google.golang.org/genproto/googleapis/api/metric"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type MetricsTestServer struct {
+	lis                         net.Listener
+	srv                         *grpc.Server
+	Endpoint                    string
+	userAgent                   string
+	createMetricDescriptorReqs  []*monitoringpb.CreateMetricDescriptorRequest
+	createServiceTimeSeriesReqs []*monitoringpb.CreateTimeSeriesRequest
+	RetryCount                  int
+	mu                          sync.Mutex
+}
+
+func (m *MetricsTestServer) Shutdown() {
+	// this will close mts.lis
+	m.srv.GracefulStop()
+}
+
+// Pops out the UserAgent from the most recent CreateTimeSeriesRequests or
+// CreateServiceTimeSeriesRequests.
+func (m *MetricsTestServer) UserAgent() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ua := m.userAgent
+	m.userAgent = ""
+	return ua
+}
+
+// Pops out the CreateServiceTimeSeriesRequests which the test server has
+// received so far.
+func (m *MetricsTestServer) CreateServiceTimeSeriesRequests() []*monitoringpb.CreateTimeSeriesRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	reqs := m.createServiceTimeSeriesReqs
+	m.createServiceTimeSeriesReqs = nil
+	return reqs
+}
+
+func (m *MetricsTestServer) appendCreateMetricDescriptorReq(
+	req *monitoringpb.CreateMetricDescriptorRequest,
+) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.createMetricDescriptorReqs = append(m.createMetricDescriptorReqs, req)
+}
+
+func (m *MetricsTestServer) appendCreateServiceTimeSeriesReq(
+	ctx context.Context,
+	req *monitoringpb.CreateTimeSeriesRequest,
+) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.createServiceTimeSeriesReqs = append(m.createServiceTimeSeriesReqs, req)
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		m.userAgent = strings.Join(md.Get("User-Agent"), ";")
+	}
+}
+
+func (m *MetricsTestServer) Serve() error {
+	return m.srv.Serve(m.lis)
+}
+
+type fakeMetricServiceServer struct {
+	monitoringpb.UnimplementedMetricServiceServer
+	metricsTestServer *MetricsTestServer
+}
+
+func (f *fakeMetricServiceServer) CreateServiceTimeSeries(
+	ctx context.Context,
+	req *monitoringpb.CreateTimeSeriesRequest,
+) (*emptypb.Empty, error) {
+	f.metricsTestServer.appendCreateServiceTimeSeriesReq(ctx, req)
+	return &emptypb.Empty{}, nil
+}
+
+func (f *fakeMetricServiceServer) CreateMetricDescriptor(
+	ctx context.Context,
+	req *monitoringpb.CreateMetricDescriptorRequest,
+) (*metricpb.MetricDescriptor, error) {
+	f.metricsTestServer.appendCreateMetricDescriptorReq(req)
+	return &metricpb.MetricDescriptor{}, nil
+}
+
+func NewMetricTestServer() (*MetricsTestServer, error) {
+	srv := grpc.NewServer(
+		grpc.KeepaliveParams(keepalive.ServerParameters{Time: 5 * time.Minute}),
+	)
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		return nil, err
+	}
+	testServer := &MetricsTestServer{
+		Endpoint: lis.Addr().String(),
+		lis:      lis,
+		srv:      srv,
+	}
+
+	monitoringpb.RegisterMetricServiceServer(
+		srv,
+		&fakeMetricServiceServer{metricsTestServer: testServer},
+	)
+
+	return testServer, nil
+}

--- a/adapter/metrics_test.go
+++ b/adapter/metrics_test.go
@@ -1,0 +1,88 @@
+//go:build unit
+// +build unit
+
+/*
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapter
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TODO: Add unit tests to verify metric population affter integration with
+// AdaptMessage is done.
+
+// TestGenerateClientHash tests the generateClientHash function.
+func TestGenerateClientHash(t *testing.T) {
+	tests := []struct {
+		name             string
+		clientUID        string
+		expectedValue    string
+		expectedLength   int
+		expectedMaxValue int64
+	}{
+		{"Simple UID", "exampleUID", "00006b", 6, 0x3FF},
+		{"Empty UID", "", "000000", 6, 0x3FF},
+		{"Special Characters", "!@#$%^&*()", "000389", 6, 0x3FF},
+		{
+			"Very Long UID",
+			"aVeryLongUniqueIdentifierThatExceedsNormalLength",
+			"000125",
+			6,
+			0x3FF,
+		},
+		{"Numeric UID", "1234567890", "00003e", 6, 0x3FF},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hash := generateClientHash(tt.clientUID)
+			if hash != tt.expectedValue {
+				t.Errorf("expected hash value %s, got %s", tt.expectedValue, hash)
+			}
+			// Check if the hash length is 6
+			if len(hash) != tt.expectedLength {
+				t.Errorf(
+					"expected hash length %d, got %d",
+					tt.expectedLength,
+					len(hash),
+				)
+			}
+
+			// Check if the hash is in the range [000000, 0003ff]
+			hashValue, err := parseHex(hash)
+			if err != nil {
+				t.Errorf("failed to parse hash: %v", err)
+			}
+			if hashValue < 0 || hashValue > tt.expectedMaxValue {
+				t.Errorf(
+					"expected hash value in range [0, %d], got %d",
+					tt.expectedMaxValue,
+					hashValue,
+				)
+			}
+		})
+	}
+}
+
+// parseHex converts a hexadecimal string to an int64.
+func parseHex(hexStr string) (int64, error) {
+	var value int64
+	_, err := fmt.Sscanf(hexStr, "%x", &value)
+	return value, err
+}

--- a/go.mod
+++ b/go.mod
@@ -3,19 +3,27 @@ module github.com/googleapis/go-spanner-cassandra
 go 1.23.0
 
 require (
+	cloud.google.com/go/monitoring v1.24.1
 	cloud.google.com/go/spanner v1.79.0
 	github.com/datastax/go-cassandra-native-protocol v0.0.0-20240903140133-605a850e203b
 	github.com/gocql/gocql v1.7.0
 	github.com/google/go-cmp v0.7.0
+	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.14.1
 	github.com/hashicorp/golang-lru v1.0.2
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.35.0
+	go.opentelemetry.io/contrib/detectors/gcp v1.35.0
+	go.opentelemetry.io/otel v1.35.0
+	go.opentelemetry.io/otel/metric v1.35.0
+	go.opentelemetry.io/otel/sdk/metric v1.35.0
 	go.uber.org/zap v1.27.0
 	google.golang.org/api v0.228.0
+	google.golang.org/genproto/googleapis/api v0.0.0-20250407143221-ac9807e6c755
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250407143221-ac9807e6c755
 	google.golang.org/grpc v1.71.1
 	google.golang.org/protobuf v1.36.6
+	gopkg.in/inf.v0 v0.9.1
 )
 
 require (
@@ -28,6 +36,7 @@ require (
 	cloud.google.com/go/longrunning v0.6.6 // indirect
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -50,7 +59,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
@@ -79,8 +87,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 // indirect
-	go.opentelemetry.io/otel v1.35.0 // indirect
-	go.opentelemetry.io/otel/metric v1.35.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.35.0 // indirect
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.37.0 // indirect
@@ -91,7 +98,5 @@ require (
 	golang.org/x/text v0.24.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
 	google.golang.org/genproto v0.0.0-20250303144028-a0af3efb3deb // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20250407143221-ac9807e6c755 // indirect
-	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ cloud.google.com/go/iam v1.4.2 h1:4AckGYAYsowXeHzsn/LCKWIwSWLkdb0eGjH8wWkd27Q=
 cloud.google.com/go/iam v1.4.2/go.mod h1:REGlrt8vSlh4dfCJfSEcNjLGq75wW75c5aU3FLOYq34=
 cloud.google.com/go/longrunning v0.6.6 h1:XJNDo5MUfMM05xK3ewpbSdmt7R2Zw+aQEMbdQR65Rbw=
 cloud.google.com/go/longrunning v0.6.6/go.mod h1:hyeGJUrPHcx0u2Uu1UFSoYZLn4lkMrccJig0t4FI7yw=
+cloud.google.com/go/monitoring v1.24.1 h1:vKiypZVFD/5a3BbQMvI4gZdl8445ITzXFh257XBgrS0=
+cloud.google.com/go/monitoring v1.24.1/go.mod h1:Z05d1/vn9NaujqY2voG6pVQXoJGbp+r3laV+LySt9K0=
 cloud.google.com/go/spanner v1.79.0 h1:HSg+P01K6I1ZFxvLGYToLdZkp+noM7P777Hd/ZHFvdk=
 cloud.google.com/go/spanner v1.79.0/go.mod h1:224ub0ngSaiy7SJI7QZ1pu9zoVPt6CgfwDGBNhUUuzU=
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
@@ -20,6 +22,8 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 h1:bvDV9
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0 h1:ErKg/3iS1AKcTkf3yixlZ54f9U1rljCkQyEXWUnIUxc=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0/go.mod h1:yAZHSGnqScoU556rBOVkwLze6WP5N+U11RHuWaGVxwY=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 h1:mXoPYz/Ul5HYEDvkta6I8/rnYM5gSdSV2tJ6XbZuEtY=
@@ -177,6 +181,8 @@ github.com/yusufpapurcu/wmi v1.2.3 h1:E1ctvB7uKFMOJw3fdOW32DwGE9I7t++CRUEMKvFoFi
 github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
+go.opentelemetry.io/contrib/detectors/gcp v1.35.0 h1:bGvFt68+KTiAKFlacHW6AhA56GF2rS0bdD3aJYEnmzA=
+go.opentelemetry.io/contrib/detectors/gcp v1.35.0/go.mod h1:qGWP8/+ILwMRIUf9uIVLloR1uo5ZYAslM4O6OqUi1DA=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 h1:x7wzEgXfnzJcHDwStJT+mxOz4etr2EcexjqhBvmoakw=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0/go.mod h1:rg+RlpR5dKwaS95IyyZqj5Wd4E13lk/msnTS0Xl9lJM=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 h1:sbiXRNDSWJOTobXh5HyQKjq6wUC5tNybqjIqDpAY4CU=


### PR DESCRIPTION
This is a draft for **initial experiments**, and all changes remain roughly same with built-in metric impls under [google-cloud-go/spanner](https://github.com/googleapis/google-cloud-go/blob/main/spanner/) except for below changes.

- Only operation count and operation latencies are included as an initial step. Removed all unrelated components.
- Client name and version are `go-spanner-cassandra` specific.
- Unit test for actual metric values population is not added because we have not integrate it with `AdaptMessage` yet.

In later prs I will work on exposing a configurable option and injecting this exporter when calling `AdaptMessage`.