### PR TITLE
chore: add utils for built-in metric method name and grpc status retrieval

### DIFF
--- a/adapter/executor_test.go
+++ b/adapter/executor_test.go
@@ -28,22 +28,6 @@ import (
 )
 
 func TestIsDML(t *testing.T) {
-	// Helper function to create a frame with a given message body
-	newFrameWithMessage := func(msg message.Message) *frame.Frame {
-		opCode := msg.GetOpCode()
-		return &frame.Frame{
-			Header: &frame.Header{
-				Version:  primitive.ProtocolVersion4, // Or any relevant version
-				Flags:    0,
-				StreamId: 1,
-				OpCode:   opCode,
-			},
-			Body: &frame.Body{
-				Message: msg,
-			},
-		}
-	}
-
 	testCases := []struct {
 		name     string
 		frame    *frame.Frame

--- a/adapter/test_util.go
+++ b/adapter/test_util.go
@@ -28,6 +28,7 @@ import (
 	"github.com/datastax/go-cassandra-native-protocol/datatype"
 	"github.com/datastax/go-cassandra-native-protocol/frame"
 	"github.com/datastax/go-cassandra-native-protocol/message"
+	"github.com/datastax/go-cassandra-native-protocol/primitive"
 	"google.golang.org/api/option"
 	"google.golang.org/api/option/internaloption"
 	"google.golang.org/grpc"
@@ -48,6 +49,21 @@ var (
 		internaloption.SkipDialSettingsValidation(),
 	}
 )
+
+func newFrameWithMessage(msg message.Message) *frame.Frame {
+	opCode := msg.GetOpCode()
+	return &frame.Frame{
+		Header: &frame.Header{
+			Version:  primitive.ProtocolVersion4,
+			Flags:    0,
+			StreamId: 1,
+			OpCode:   opCode,
+		},
+		Body: &frame.Body{
+			Message: msg,
+		},
+	}
+}
 
 type GrpcFuncs struct {
 	CreateSession func(ctx context.Context, req *adapterpb.CreateSessionRequest, cl *AdapterClient) (*adapterpb.Session, error)


### PR DESCRIPTION
These utils will be called in a defer block in [writeGrpcResponseBackToTcp](https://github.com/googleapis/go-spanner-cassandra/blob/main/adapter/connection.go#L92)