### PR TITLE
chore: reuse codec for all requests

### DIFF
--- a/adapter/tcp.go
+++ b/adapter/tcp.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/datastax/go-cassandra-native-protocol/frame"
 	"github.com/googleapis/go-spanner-cassandra/logger"
 
 	"go.uber.org/zap"
@@ -118,6 +119,8 @@ func NewTCPProxy(opts Options) (*TCPProxy, error) {
 				driverConn:  conn,
 				globalState: proxy.globalState,
 				md:          cl.md,
+				codec:       frame.NewCodec(),
+				rawCodec:    frame.NewRawCodec(),
 			}
 
 			go dc.handleConnection(ctx)

--- a/adapter/test_util.go
+++ b/adapter/test_util.go
@@ -47,6 +47,8 @@ var (
 		option.WithoutAuthentication(),
 		internaloption.SkipDialSettingsValidation(),
 	}
+	codec    = frame.NewCodec()
+	rawCodec = frame.NewRawCodec()
 )
 
 type GrpcFuncs struct {
@@ -172,7 +174,6 @@ func (mc *Mock_Cassandra_AdaptMessageClient) constructAdaptMessageResponse(
 
 	var payload []byte
 	if mc.returnResponsesInChunks {
-		rawCodec := frame.NewRawCodec()
 		if !mc.bodyResponsesReturned {
 			rawFrame, err := rawCodec.ConvertToRawFrame(frm)
 			if err != nil {
@@ -188,7 +189,6 @@ func (mc *Mock_Cassandra_AdaptMessageClient) constructAdaptMessageResponse(
 			payload = rawHeader.Bytes()
 		}
 	} else {
-		codec := frame.NewCodec()
 		buf := bytes.NewBuffer(nil)
 		err := codec.EncodeFrame(frm, buf)
 		if err != nil {
@@ -492,7 +492,6 @@ func MockAdaptMessageGrpc(returnResponsesInChunks bool) {
 		if req.Protocol != "cassandra" {
 			return nil, errors.New("unsupported protocol type")
 		}
-		codec := frame.NewCodec()
 		frame, err := codec.DecodeFrame(bytes.NewBuffer(req.Payload))
 		if err != nil {
 			fmt.Println(err)

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -29,7 +29,10 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-var zapLog *zap.Logger
+var (
+	zapLog *zap.Logger
+	codec  = frame.NewCodec()
+)
 
 func SetupGlobalLogger(level string) error {
 	var config zap.Config
@@ -76,7 +79,6 @@ func Fatal(message string, fields ...zap.Field) {
 }
 
 func DumpRequest(req *adapterpb.AdaptMessageRequest) error {
-	codec := frame.NewCodec()
 	frame, err := codec.DecodeFrame(bytes.NewBuffer(req.Payload))
 	if err != nil {
 		Debug("Error dumping request,", zap.Error(err))
@@ -90,7 +92,6 @@ func DumpRequest(req *adapterpb.AdaptMessageRequest) error {
 }
 
 func DumpResponse(resp *adapterpb.AdaptMessageResponse) error {
-	codec := frame.NewCodec()
 	frame, err := codec.DecodeFrame(bytes.NewBuffer(resp.Payload))
 	if err != nil {
 		Debug("Error dumping response,", zap.Error(err))


### PR DESCRIPTION
Avoid re create a codec struct in each request loop iteration.