### PR TITLE
feat: expose options to override spanner endpoint and talking to spanner insecurely.

### DIFF
--- a/adapter/client.go
+++ b/adapter/client.go
@@ -33,6 +33,7 @@ import (
 	"google.golang.org/api/option/internaloption"
 	"google.golang.org/grpc"
 
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	_ "google.golang.org/grpc/xds/googledirectpath"
 
@@ -187,6 +188,12 @@ func getAllClientOpts(
 			clientDefaultOpts,
 			internaloption.EnableDirectPath(true),
 			internaloption.EnableDirectPathXds(),
+		)
+	}
+	if opts.Insecure {
+		clientDefaultOpts = append(
+			clientDefaultOpts,
+			option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
 		)
 	}
 

--- a/adapter/options.go
+++ b/adapter/options.go
@@ -37,4 +37,7 @@ type Options struct {
 	MaxCommitDelay int
 	// Optional google api opts. Default to empty.
 	GoogleApiOpts []option.ClientOption
+	// Optional boolean indicate whether to use insecure grpc connection.
+	// Defaults to false.
+	Insecure bool
 }

--- a/cassandra/gocql/spanner.go
+++ b/cassandra/gocql/spanner.go
@@ -52,6 +52,9 @@ type Options struct {
 	LogLevel string
 	// Optional google api opts. Default to empty.
 	GoogleApiOpts []option.ClientOption
+	// Optional boolean indicate whether to use insecure grpc connection.
+	// Defaults to false.
+	Insecure bool
 }
 
 type ProxyAddressTranslator struct {
@@ -86,6 +89,7 @@ func NewCluster(
 			DisableAdaptMessageRetry: opts.DisableAdaptMessageRetry,
 			MaxCommitDelay:           opts.MaxCommitDelay,
 			GoogleApiOpts:            opts.GoogleApiOpts,
+			Insecure:                 opts.Insecure,
 		},
 	)
 	if err != nil {

--- a/cassandra_launcher.go
+++ b/cassandra_launcher.go
@@ -66,6 +66,17 @@ func main() {
 		0,
 		"The maximum delay in milliseconds. Default is 0 (disabled).",
 	)
+	spannerEndpoint := flag.String(
+		"endpoint",
+		"",
+		"The Spanner service endpoint (optional). Default to Cloud Spanner endpoint: spanner.googleapis.com:443",
+	)
+
+	insecure := flag.Bool(
+		"insecure",
+		false,
+		"Whether to use insecure connection to Spanner. Default to false.",
+	)
 
 	flag.Parse()
 
@@ -81,6 +92,8 @@ func main() {
 		NumGrpcChannels: *numGrpcChannels,
 		LogLevel:        *logLevel,
 		MaxCommitDelay:  *maxCommitDelay,
+		SpannerEndpoint: *spannerEndpoint,
+		Insecure:        *insecure,
 	}
 
 	cluster := spanner.NewCluster(opts)


### PR DESCRIPTION
expose options to override spanner endpoint and talking to spanner insecurely. It will be useful to test with experimental/fake spanner server.

Example usage:
```
go run cassandra_launcher.go \
  -db "projects/<project>/instances/<instance>/databases/cassandra" \
  -endpoint <spanner-endpoint-url> \
  -insecure
```
