### PR TITLE
feat: expose options for connecting to experimental host via tls/mTLS

### DIFF
--- a/adapter/client.go
+++ b/adapter/client.go
@@ -18,6 +18,8 @@ package adapter
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"math"
 	"os"
@@ -33,6 +35,7 @@ import (
 	"google.golang.org/api/option/internaloption"
 	"google.golang.org/grpc"
 
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	_ "google.golang.org/grpc/xds/googledirectpath"
@@ -132,11 +135,14 @@ func newAdapterClient(
 		md:   metadata.Pairs(resourcePrefixHeader, opts.DatabaseUri),
 	}
 
+	var err error
 	// Build grpc options.
-	dialOpts := getAllClientOpts(opts)
+	dialOpts, err := getAllClientOpts(opts)
+	if err != nil {
+		return nil, err
+	}
 
 	// Create a default gapic client.
-	var err error
 	cl.gapicClient, err = vkit.NewClient(ctx, dialOpts...)
 	if err != nil {
 		return nil, err
@@ -161,13 +167,51 @@ func generatedGRPCClientOptions() []option.ClientOption {
 	}
 }
 
+// createExperimentalHostCredentials is only supported for connecting to experimental
+// hosts. It reads the provided CA certificate file and optionally the
+// client certificate and key files to set up TLS or mutual TLS credentials, and
+// creates gRPC dial options to connect to an experimental host endpoint.
+func createExperimentalHostCredentials(caCertFile, clientCertificateFile, clientCertificateKey string) (option.ClientOption, error) {
+	if caCertFile == "" {
+		return nil, nil
+	}
+	ca, err := os.ReadFile(caCertFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA certificate file: %w", err)
+	}
+	capool := x509.NewCertPool()
+	if !capool.AppendCertsFromPEM(ca) {
+		return nil, fmt.Errorf("failed to append the CA certificate to CA pool")
+	}
+
+	if clientCertificateFile != "" && clientCertificateKey != "" {
+		// Setting up mutual TLS with both the CA certificate and client certificate.
+		cert, err := tls.LoadX509KeyPair(clientCertificateFile, clientCertificateKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client certificate/key: %w", err)
+		}
+		creds := credentials.NewTLS(&tls.Config{
+			RootCAs:      capool,
+			Certificates: []tls.Certificate{cert},
+		})
+		return option.WithGRPCDialOption(grpc.WithTransportCredentials(creds)), nil
+	}
+	if clientCertificateFile != "" || clientCertificateKey != "" {
+		return nil, fmt.Errorf("both client certificate and key must be provided for mTLS, but only one was provided")
+	}
+
+	// Setting up TLS with only the CA certificate.
+	creds := credentials.NewTLS(&tls.Config{RootCAs: capool})
+	return option.WithGRPCDialOption(grpc.WithTransportCredentials(creds)), nil
+}
+
 // Combines the default options from the generated client, the default options
 // of the hand-written client and the user options to one list of options.
 // Precedence: user provided GoogleApiOpts > clientDefaultOpts >
 // generatedDefaultOpts
 func getAllClientOpts(
 	opts Options,
-) []option.ClientOption {
+) ([]option.ClientOption, error) {
 	if opts.SpannerEndpoint == "" {
 		opts.SpannerEndpoint = defaultSpannerEndpoint
 	}
@@ -190,7 +234,17 @@ func getAllClientOpts(
 			internaloption.EnableDirectPathXds(),
 		)
 	}
-	if opts.Insecure {
+	if opts.ExperimentalHost {
+		clientDefaultOpts = append(clientDefaultOpts, option.WithoutAuthentication())
+		credOpts, err := createExperimentalHostCredentials(opts.CaCertificate, opts.ClientCertificate, opts.ClientKey)
+		if err != nil {
+			return nil, err
+		}
+		if credOpts != nil {
+			clientDefaultOpts = append(clientDefaultOpts, credOpts)
+		}
+	}
+	if opts.UsePlainText {
 		clientDefaultOpts = append(
 			clientDefaultOpts,
 			option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
@@ -199,7 +253,7 @@ func getAllClientOpts(
 
 	allDefaultOpts := append(generatedDefaultOpts, clientDefaultOpts...)
 
-	return append(allDefaultOpts, opts.GoogleApiOpts...)
+	return append(allDefaultOpts, opts.GoogleApiOpts...), nil
 }
 
 func (cl *AdapterClient) getMetadata() metadata.MD {

--- a/adapter/client_test.go
+++ b/adapter/client_test.go
@@ -21,6 +21,8 @@ package adapter
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -77,6 +79,110 @@ func TestGetOrRefreshSession(t *testing.T) {
 				)
 			}
 
+		})
+	}
+}
+
+func TestGetAllClientOpts(t *testing.T) {
+	t.Parallel()
+	opts := Options{}
+	clientOpts, err := getAllClientOpts(opts)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, clientOpts)
+
+	opts.SpannerEndpoint = "some.endpoint"
+	clientOpts, err = getAllClientOpts(opts)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, clientOpts)
+
+	opts.UsePlainText = true
+	clientOpts, err = getAllClientOpts(opts)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, clientOpts)
+
+	opts.UsePlainText = false
+	opts.ExperimentalHost = true
+	clientOpts, err = getAllClientOpts(opts)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, clientOpts)
+}
+
+func TestCreateExperimentalHostNoCredentials(t *testing.T) {
+	t.Parallel()
+	creds, err := createExperimentalHostCredentials("", "", "")
+	assert.NoError(t, err)
+	assert.Nil(t, creds)
+}
+
+func createDummyCerts(t *testing.T) (caFile, certFile, keyFile string) {
+	t.Helper()
+	dir := t.TempDir()
+	caFile = filepath.Join(dir, "ca.crt")
+	certFile = filepath.Join(dir, "client.crt")
+	keyFile = filepath.Join(dir, "client.key")
+
+	// Simplified dummy content, not valid certs
+	assert.NoError(t, os.WriteFile(caFile, []byte("CA CERT"), 0644))
+	assert.NoError(t, os.WriteFile(certFile, []byte("CLIENT CERT"), 0644))
+	assert.NoError(t, os.WriteFile(keyFile, []byte("CLIENT KEY"), 0644))
+	return
+}
+
+func TestCreateExperimentalHostCredentials(t *testing.T) {
+	caFile, certFile, keyFile := createDummyCerts(t)
+
+	tests := []struct {
+		name       string
+		caCert     string
+		clientCert string
+		clientKey  string
+		wantErr    bool
+		expectTLS  bool
+		expectMTLS bool
+	}{
+		{
+			name:    "No certs",
+			wantErr: false,
+		},
+		{
+			name:    "CA cert only - invalid content",
+			caCert:  caFile, // Will fail to parse as PEM
+			wantErr: true,
+		},
+		{
+			name:       "Client cert without key",
+			caCert:     caFile,
+			clientCert: certFile,
+			wantErr:    true,
+		},
+		{
+			name:      "Client key without cert",
+			caCert:    caFile,
+			clientKey: keyFile,
+			wantErr:   true,
+		},
+		{
+			name:       "All certs - invalid content",
+			caCert:     caFile,
+			clientCert: certFile,
+			clientKey:  keyFile,
+			wantErr:    true, // Will fail to load key pair
+		},
+		// Success cases are hard to test without valid PEM data
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt, err := createExperimentalHostCredentials(tt.caCert, tt.clientCert, tt.clientKey)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("createExperimentalHostCredentials() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && tt.caCert != "" {
+				assert.NotNil(t, opt, "Expected a ClientOption to be returned")
+			} else if !tt.wantErr && tt.caCert == "" {
+				assert.Nil(t, opt, "Expected nil option when no CA cert")
+			}
 		})
 	}
 }

--- a/adapter/options.go
+++ b/adapter/options.go
@@ -37,7 +37,15 @@ type Options struct {
 	MaxCommitDelay int
 	// Optional google api opts. Default to empty.
 	GoogleApiOpts []option.ClientOption
-	// Optional boolean indicate whether to use insecure grpc connection.
+	// Optional boolean indicate whether to use plain-text connection.
 	// Defaults to false.
-	Insecure bool
+	UsePlainText bool
+	// Optional boolean indicate whether endpoint is experimental host instance
+	ExperimentalHost bool
+	// Optional string CA certificate file path for establishing tls connection
+	CaCertificate string
+	// Optional string client certificate file path for establishing mTLS connection
+	ClientCertificate string
+	// Optional string client key file path for establishing mTLS connection
+	ClientKey string
 }

--- a/cassandra/gocql/integration_test.go
+++ b/cassandra/gocql/integration_test.go
@@ -42,6 +42,8 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"gopkg.in/inf.v0"
 )
 
@@ -146,17 +148,27 @@ func assertDeepEqual(
 func setupAndRunSpanner(m *testing.M, spannerEndpoint string) int {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	defer cancel()
+	experimentalHost := os.Getenv("EXPERIMENTAL_HOST")
 	instanceURI := os.Getenv("INTEGRATION_TEST_INSTANCE")
-	if instanceURI == "" {
+	if instanceURI == "" && experimentalHost == "" {
 		log.Fatalf(
 			"environment variable INTEGRATION_TEST_INSTANCE is not set or is empty",
 		)
 	}
+	if experimentalHost != "" {
+		instanceURI = "projects/default/instances/default"
+		spannerEndpoint = experimentalHost
+	}
 	databaseUri = fmt.Sprintf("%s/databases/%s", instanceURI, keyspace)
 	var err error
-	adminClient, err = database.NewDatabaseAdminClient(ctx, []option.ClientOption{
+	clientOpts := []option.ClientOption{
 		option.WithEndpoint(spannerEndpoint),
-	}...)
+	}
+	if experimentalHost != "" {
+		clientOpts = append(clientOpts, option.WithoutAuthentication())
+		clientOpts = append(clientOpts, option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())))
+	}
+	adminClient, err = database.NewDatabaseAdminClient(ctx, clientOpts...)
 	if err != nil {
 		log.Fatalf(err.Error())
 	}
@@ -193,6 +205,11 @@ func setupAndRunSpanner(m *testing.M, spannerEndpoint string) int {
 		SpannerEndpoint: spannerEndpoint,
 		LogLevel:        "warn",
 		MaxCommitDelay:  randomMaxCommitDelay,
+	}
+
+	if experimentalHost != "" {
+		opts.ExperimentalHost = true
+		opts.UsePlainText = true
 	}
 
 	cluster = NewCluster(opts)

--- a/cassandra/gocql/integration_test.go
+++ b/cassandra/gocql/integration_test.go
@@ -152,7 +152,7 @@ func setupAndRunSpanner(m *testing.M, spannerEndpoint string) int {
 	instanceURI := os.Getenv("INTEGRATION_TEST_INSTANCE")
 	if instanceURI == "" && experimentalHost == "" {
 		log.Fatalf(
-			"environment variable INTEGRATION_TEST_INSTANCE is not set or is empty",
+			"at least one of the environment variables INTEGRATION_TEST_INSTANCE or EXPERIMENTAL_HOST must be set and non-empty for the integration test",
 		)
 	}
 	if experimentalHost != "" {

--- a/cassandra/gocql/spanner.go
+++ b/cassandra/gocql/spanner.go
@@ -20,6 +20,7 @@ package spanner
 import (
 	"encoding/binary"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/gocql/gocql"
@@ -52,9 +53,17 @@ type Options struct {
 	LogLevel string
 	// Optional google api opts. Default to empty.
 	GoogleApiOpts []option.ClientOption
-	// Optional boolean indicate whether to use insecure grpc connection.
+	// Optional boolean indicate whether to use plain-text connection.
 	// Defaults to false.
-	Insecure bool
+	UsePlainText bool
+	// Optional boolean indicate whether spanner endpoint is a Experimental Host instance
+	ExperimentalHost bool
+	// Optional string CA certificate file path for establishing tls connection
+	CaCertificate string
+	// Optional string client certificate file path for establishing mTLS connection
+	ClientCertificate string
+	// Optional string client key file path for establishing mTLS connection
+	ClientKey string
 }
 
 type ProxyAddressTranslator struct {
@@ -78,6 +87,11 @@ func NewCluster(
 			err,
 		)
 	}
+	if opts.ExperimentalHost {
+		if !strings.Contains(opts.DatabaseUri, "/") {
+			opts.DatabaseUri = "projects/default/instances/default/databases/" + opts.DatabaseUri
+		}
+	}
 	// Create a new local Cassandra proxy.
 	proxy, err := adapter.NewTCPProxy(
 		adapter.Options{
@@ -89,7 +103,11 @@ func NewCluster(
 			DisableAdaptMessageRetry: opts.DisableAdaptMessageRetry,
 			MaxCommitDelay:           opts.MaxCommitDelay,
 			GoogleApiOpts:            opts.GoogleApiOpts,
-			Insecure:                 opts.Insecure,
+			UsePlainText:             opts.UsePlainText,
+			ExperimentalHost:         opts.ExperimentalHost,
+			CaCertificate:            opts.CaCertificate,
+			ClientCertificate:        opts.ClientCertificate,
+			ClientKey:                opts.ClientKey,
 		},
 	)
 	if err != nil {

--- a/cassandra/gocql/spanner.go
+++ b/cassandra/gocql/spanner.go
@@ -87,10 +87,8 @@ func NewCluster(
 			err,
 		)
 	}
-	if opts.ExperimentalHost {
-		if !strings.Contains(opts.DatabaseUri, "/") {
-			opts.DatabaseUri = "projects/default/instances/default/databases/" + opts.DatabaseUri
-		}
+	if opts.ExperimentalHost && !strings.Contains(opts.DatabaseUri, "/") {
+		opts.DatabaseUri = "projects/default/instances/default/databases/" + opts.DatabaseUri
 	}
 	// Create a new local Cassandra proxy.
 	proxy, err := adapter.NewTCPProxy(

--- a/cassandra/gocql/spanner_test.go
+++ b/cassandra/gocql/spanner_test.go
@@ -203,6 +203,52 @@ func TestBasicBatch(t *testing.T) {
 	}
 }
 
+func TestNewCluster_ExperimentalHost(t *testing.T) {
+	t.Cleanup(adapter.ResetGrpcFuncs())
+	adapter.MockCreateSessionGrpc()
+	adapter.MockAdaptMessageGrpc(false)
+
+	testCases := []struct {
+		name             string
+		initialDatabase  string
+		expectedDatabase string
+		experimentalHost bool
+	}{
+		{
+			name:             "ExperimentalHost with simple db name",
+			initialDatabase:  "test-db",
+			expectedDatabase: "projects/default/instances/default/databases/test-db",
+			experimentalHost: true,
+		},
+		{
+			name:             "ExperimentalHost with full db name",
+			initialDatabase:  "projects/p/instances/i/databases/d",
+			expectedDatabase: "projects/p/instances/i/databases/d",
+			experimentalHost: true,
+		},
+		{
+			name:             "No ExperimentalHost",
+			initialDatabase:  "test-db",
+			expectedDatabase: "test-db",
+			experimentalHost: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := &Options{
+				DatabaseUri:      tc.initialDatabase,
+				GoogleApiOpts:    adapter.SkipAuthOpts,
+				ExperimentalHost: tc.experimentalHost,
+			}
+			cluster := NewCluster(opts)
+			require.NotNil(t, cluster)
+			assert.Equal(t, tc.expectedDatabase, opts.DatabaseUri)
+			teardownCluster(t, cluster)
+		})
+	}
+}
+
 func TestNewClusterPanicsOnInvalidLogLevel(t *testing.T) {
 	t.Cleanup(adapter.ResetGrpcFuncs())
 	testCases := []struct {

--- a/cassandra_launcher.go
+++ b/cassandra_launcher.go
@@ -72,10 +72,34 @@ func main() {
 		"The Spanner service endpoint (optional). Default to Cloud Spanner endpoint: spanner.googleapis.com:443",
 	)
 
-	insecure := flag.Bool(
-		"insecure",
+	usePlainText := flag.Bool(
+		"usePlainText",
 		false,
-		"Whether to use insecure connection to Spanner. Default to false.",
+		"Whether to use plain-text connection to Spanner. Default to false.",
+	)
+
+	experimentalHost := flag.Bool(
+		"experimentalHost",
+		false,
+		"Spanner Endpoint is an experimental host instance (optional). Default to false.",
+	)
+
+	caCertificate := flag.String(
+		"caCertificate",
+		"",
+		"The CA certificate file path for establishing tls connection(optional). Default to empty.",
+	)
+
+	clientCertificate := flag.String(
+		"clientCertificate",
+		"",
+		"The client certificate file path for establishing mTLS connection(optional). Default to empty.",
+	)
+
+	clientKey := flag.String(
+		"clientKey",
+		"",
+		"The client key file path for establishing mTLS connection(optional). Default to empty.",
 	)
 
 	flag.Parse()
@@ -87,13 +111,17 @@ func main() {
 	}
 
 	opts := &spanner.Options{
-		DatabaseUri:     *databaseURI,
-		TCPEndpoint:     *tcpEndpoint,
-		NumGrpcChannels: *numGrpcChannels,
-		LogLevel:        *logLevel,
-		MaxCommitDelay:  *maxCommitDelay,
-		SpannerEndpoint: *spannerEndpoint,
-		Insecure:        *insecure,
+		DatabaseUri:       *databaseURI,
+		TCPEndpoint:       *tcpEndpoint,
+		NumGrpcChannels:   *numGrpcChannels,
+		LogLevel:          *logLevel,
+		MaxCommitDelay:    *maxCommitDelay,
+		SpannerEndpoint:   *spannerEndpoint,
+		UsePlainText:      *usePlainText,
+		ExperimentalHost:  *experimentalHost,
+		CaCertificate:     *caCertificate,
+		ClientCertificate: *clientCertificate,
+		ClientKey:         *clientKey,
 	}
 
 	cluster := spanner.NewCluster(opts)


### PR DESCRIPTION
- Extend go-spanner-cassandra support to connect to experimental host endpoints via tls/mTLS.
- Extend Integration Tests to make them compatible with Experimental Host endpoints over plain-text

Plain-Text
```
go run cassandra_launcher.go -db test-db -endpoint localhost:15000 -experimentalHost  -usePlainText -tcp ":9042" -grpc-channels 1
```

TLS connection
```
go run cassandra_launcher.go -db test-db -endpoint localhost:15000 -experimentalHost  -tcp ":9042" -grpc-channels 1 -caCertificate /tmp/exph/ca-certificates/ca.crt
```

mTLS connection
```
go run cassandra_launcher.go -db test-db -endpoint localhost:15000 -experimentalHost  -tcp ":9042" -grpc-channels 1 -caCertificate /tmp/exph/ca-certificates/ca.crt -clientCertificate /tmp/exph/certs/client.crt -clientKey /tmp/exph/certs/client.key
```

Integration Tests :

```
export EXPERIMENTAL_HOST=localhost:15000
go test -v ./cassandra/gocql -tags=integration -target=spanner
```
