### PR TITLE
feat: add TLS support to TCP proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ For Go applications already using the `gocql` library, integrating the Spanner C
       opts := &spanner.Options{
           // Required: Specify the Spanner database URI
           DatabaseUri: "projects/your_gcp_project/instances/your_spanner_instance/databases/your_spanner_database",
+          // Optional: Specify TLS certificates for the proxy listener
+          ProxyTLSCertFile: "/path/to/cert.pem",
+          ProxyTLSKeyFile:  "/path/to/key.pem",
       }
       // Optional: Configure other gocql cluster settings as needed
       cluster := spanner.NewCluster(opts)
@@ -127,7 +130,27 @@ For non-Go applications or tools like `cqlsh`, you can run the Spanner Cassandra
     * Replace the value of `-db` with your Spanner database URI.
     * You can omit the `-tcp` to use the default `:9042` and omit `-grpc-channels` to use the default 4.
 
+    * **To run with TLS enabled**, provide the paths to your server certificate and key:
+    ```bash
+    go run cassandra_launcher.go -db "projects/your_gcp_project/instances/your_spanner_instance/databases/your_spanner_database" -proxyTLSCertFile /path/to/cert.pem -proxyTLSKeyFile /path/to/key.pem
+    ```
+
     See [Options](#options) for an explanation of all further options.
+
+    **Verifying TLS Connection**
+
+    You can verify that the TLS proxy is working correctly using `openssl`:
+
+    1. Generate self-signed certificates for testing (if you don't have them):
+       ```bash
+       openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes -subj "/CN=localhost"
+       ```
+    2. Start the proxy with the generated certificates as shown above.
+    3. Verify the connection using `openssl s_client`:
+       ```bash
+       openssl s_client -connect localhost:9042 -CAfile cert.pem
+       ```
+       If successful, you should see `Verify return code: 0 (ok)` in the output.
 
 **Method 2: Run with pre-built docker image**
 
@@ -176,6 +199,14 @@ The following list contains the most frequently used startup options for Spanner
   * If you don't set a commit delay time, Spanner might set a small delay for you if it thinks that will amortize the cost of your writes.
   * You can disable commit delays for applications that are highly latency sensitive by setting the maximum commit delay time to 0.
   * Default: 0 (disabled)
+
+-proxyTLSCertFile <ProxyTLSCertFile>
+  * Optional string server certificate file path for proxy TLS connection.
+  * Must be specified together with -proxyTLSKeyFile.
+
+-proxyTLSKeyFile <ProxyTLSKeyFile>
+  * Optional string server key file path for proxy TLS connection.
+  * Must be specified together with -proxyTLSCertFile.
 ```
 
 ## Supported Cassandra Versions

--- a/adapter/options.go
+++ b/adapter/options.go
@@ -48,4 +48,8 @@ type Options struct {
 	ClientCertificate string
 	// Optional string client key file path for establishing mTLS connection
 	ClientKey string
+	// Optional string server certificate file path for proxy TLS connection
+	ProxyTLSCertFile string
+	// Optional string server key file path for proxy TLS connection
+	ProxyTLSKeyFile string
 }

--- a/adapter/tcp.go
+++ b/adapter/tcp.go
@@ -18,6 +18,7 @@ package adapter
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -76,7 +77,19 @@ func NewTCPProxy(opts Options) (*TCPProxy, error) {
 	if opts.TCPEndpoint == "" {
 		opts.TCPEndpoint = "localhost:9042"
 	}
-	proxy.listener, err = net.Listen("tcp", opts.TCPEndpoint)
+	if (opts.ProxyTLSCertFile != "") != (opts.ProxyTLSKeyFile != "") {
+		return nil, fmt.Errorf("both ProxyTLSCertFile and ProxyTLSKeyFile must be specified for TLS support")
+	}
+	if opts.ProxyTLSCertFile != "" && opts.ProxyTLSKeyFile != "" {
+		cert, err := tls.LoadX509KeyPair(opts.ProxyTLSCertFile, opts.ProxyTLSKeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load proxy TLS key pair: %w", err)
+		}
+		tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}}
+		proxy.listener, err = tls.Listen("tcp", opts.TCPEndpoint, tlsConfig)
+	} else {
+		proxy.listener, err = net.Listen("tcp", opts.TCPEndpoint)
+	}
 	if err != nil {
 		return nil, fmt.Errorf(
 			"spanner proxy failed to listen on local port: %w",

--- a/cassandra/gocql/spanner.go
+++ b/cassandra/gocql/spanner.go
@@ -64,6 +64,10 @@ type Options struct {
 	ClientCertificate string
 	// Optional string client key file path for establishing mTLS connection
 	ClientKey string
+	// Optional string server certificate file path for proxy TLS connection
+	ProxyTLSCertFile string
+	// Optional string server key file path for proxy TLS connection
+	ProxyTLSKeyFile string
 }
 
 type ProxyAddressTranslator struct {
@@ -106,6 +110,8 @@ func NewCluster(
 			CaCertificate:            opts.CaCertificate,
 			ClientCertificate:        opts.ClientCertificate,
 			ClientKey:                opts.ClientKey,
+			ProxyTLSCertFile:         opts.ProxyTLSCertFile,
+			ProxyTLSKeyFile:          opts.ProxyTLSKeyFile,
 		},
 	)
 	if err != nil {

--- a/cassandra/gocql/spanner_test.go
+++ b/cassandra/gocql/spanner_test.go
@@ -249,6 +249,71 @@ func TestNewCluster_ExperimentalHost(t *testing.T) {
 	}
 }
 
+func TestNewCluster_TLSValidation(t *testing.T) {
+	t.Cleanup(adapter.ResetGrpcFuncs())
+	adapter.MockCreateSessionGrpc()
+
+	testCases := []struct {
+		name        string
+		certFile    string
+		keyFile     string
+		expectPanic bool
+	}{
+		{
+			name:        "OnlyCertSpecified",
+			certFile:    "cert.pem",
+			keyFile:     "",
+			expectPanic: true,
+		},
+		{
+			name:        "OnlyKeySpecified",
+			certFile:    "",
+			keyFile:     "key.pem",
+			expectPanic: true,
+		},
+		{
+			name:        "BothSpecifiedButInvalid",
+			certFile:    "nonexistent.pem",
+			keyFile:     "nonexistent.pem",
+			expectPanic: true,
+		},
+		{
+			name:        "NeitherSpecified",
+			certFile:    "",
+			keyFile:     "",
+			expectPanic: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := &Options{
+				DatabaseUri:      "projects/test/instances/test/databases/test",
+				GoogleApiOpts:    adapter.SkipAuthOpts,
+				ProxyTLSCertFile: tc.certFile,
+				ProxyTLSKeyFile:  tc.keyFile,
+			}
+
+			callNewCluster := func() {
+				cluster := NewCluster(opts)
+				if cluster != nil {
+					teardownCluster(t, cluster)
+				}
+			}
+
+			if tc.expectPanic {
+				require.Panics(
+					t,
+					callNewCluster,
+					"NewCluster should panic",
+				)
+			} else {
+				require.NotPanics(t, callNewCluster, "NewCluster should not panic")
+			}
+		})
+	}
+}
+
 func TestNewClusterPanicsOnInvalidLogLevel(t *testing.T) {
 	t.Cleanup(adapter.ResetGrpcFuncs())
 	testCases := []struct {

--- a/cassandra_launcher.go
+++ b/cassandra_launcher.go
@@ -102,6 +102,18 @@ func main() {
 		"The client key file path for establishing mTLS connection(optional). Default to empty.",
 	)
 
+	proxyTLSCertFile := flag.String(
+		"proxyTLSCertFile",
+		"",
+		"The server certificate file path for proxy TLS connection(optional). Default to empty.",
+	)
+
+	proxyTLSKeyFile := flag.String(
+		"proxyTLSKeyFile",
+		"",
+		"The server key file path for proxy TLS connection(optional). Default to empty.",
+	)
+
 	flag.Parse()
 
 	if *databaseURI == "" {
@@ -122,6 +134,8 @@ func main() {
 		CaCertificate:     *caCertificate,
 		ClientCertificate: *clientCertificate,
 		ClientKey:         *clientKey,
+		ProxyTLSCertFile:  *proxyTLSCertFile,
+		ProxyTLSKeyFile:   *proxyTLSKeyFile,
 	}
 
 	cluster := spanner.NewCluster(opts)


### PR DESCRIPTION
- Add `ProxyTLSCertFile` and `ProxyTLSKeyFile` options to `adapter` and `gocql`.
- Update `tcp.go` to use `tls.Listen` when certificates are provided.
- Add validation to require both cert and key files if either is set.
- Add unit tests for TLS option validation in `spanner_test.go`.
- Update `README.md` with usage examples and verification instructions.